### PR TITLE
Remove missing supports_ap field

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -67,9 +67,9 @@ pub struct AccessToken {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Data {
+    Sensor(Sensor),
     Bridge(Bridge),
     Budget(Budget),
-    Sensor(Sensor),
     Token(Token),
     User(User),
     QueryResults(HashMap<String, Vec<QueryResult>>),
@@ -86,7 +86,6 @@ pub struct Bridge {
     pub id: String,
     pub last_seen: String,
     pub connected: bool,
-    pub supports_ap: bool,
     pub product: String,
     pub user: Option<User>,
     pub location: Option<Location>,


### PR DESCRIPTION
This fixes the following cryptic error:

```
[2023-03-14T21:54:26Z ERROR flume_water_exporter] deserialize response from https://api.flumewater.com/users/62219/devices?location=true: data did not match any variant of untagged enum Data at line 1 column 1470
```

Since any `Bridge` is now a strict subset of a `Sensor`, it needs to come later in `Data` enum, otherwise even `Sensor` is detected as a `Bridge`.

See also: https://github.com/serde-rs/serde/issues/2157